### PR TITLE
:fairy: Add github actions, test & lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        java: ['11', '17', '21']
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'temurin'
+    
+    - name: Install Leiningen
+      run: |
+        wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+        chmod +x lein
+        sudo mv lein /usr/local/bin/
+        lein version
+    
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2
+          ~/.lein
+        key: ${{ runner.os }}-lein-${{ hashFiles('project.clj') }}
+        restore-keys: |
+          ${{ runner.os }}-lein-
+    
+    - name: Install dependencies
+      run: lein deps
+    
+    - name: Run tests
+      run: lein test
+
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install clj-kondo
+      run: |
+        curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
+        chmod +x install-clj-kondo
+        sudo ./install-clj-kondo
+    
+    - name: Run clj-kondo
+      run: clj-kondo --lint src test


### PR DESCRIPTION
## Sourceryによるサマリー

GitHub Actions CIワークフローを追加し、複数のJDKバージョンでプロジェクトのテストを実行し、Clojureコードをlintします。

CI:
- Java 11、17、21のマトリックスを持つテストジョブを導入。Temurin JDKをセットアップし、Leiningenをインストールし、依存関係をキャッシュし、テストを実行します。
- ソースおよびテストディレクトリに対してclj-kondoをインストールして実行するlintジョブを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add GitHub Actions CI workflow to run project tests across multiple JDK versions and lint Clojure code

CI:
- Introduce a test job with a Java 11, 17, and 21 matrix that sets up Temurin JDK, installs Leiningen, caches dependencies, and runs tests
- Add a lint job that installs and runs clj-kondo on source and test directories

</details>