### PR TITLE
:green_apple: add security into ci

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,69 @@
+name: Security Scan
+
+on:
+  schedule:
+    # Run on the 1st of every month at 9:00 AM UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Install Clojure CLI
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2
+            ~/.gitlibs
+          key: ${{ runner.os }}-clojure-${{ hashFiles('project.clj') }}
+          restore-keys: |
+            ${{ runner.os }}-clojure-
+
+      - name: Run vulnerability scan
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          clojure -Sdeps '{:deps {io.github.clj-holmes/clj-watson {:git/tag "v6.0.1" :git/sha "b520351"}}}' \
+                  -M -m clj-watson.cli scan -p project.clj
+
+      - name: Upload scan results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vulnerability-scan-results
+          path: |
+            clj-watson-report.json
+            clj-watson-report.html
+          retention-days: 30
+
+      - name: Create issue on vulnerabilities found
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🚨 Security vulnerabilities detected in dependencies',
+              body: `Security scan has detected vulnerabilities in project dependencies.
+              
+              Please check the workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              
+              This issue was automatically created by the monthly security scan.`,
+              labels: ['security', 'dependencies']
+            })


### PR DESCRIPTION
## Sourceryによるサマリー

Clojureの依存関係に対する月次の脆弱性スキャンを実行し、検出結果を自動的に報告するGitHub Actions Security Scanワークフローを追加します。

CI:
- 月次および手動ディスパッチでトリガーされるSecurity Scanワークフローを導入
- スキャンパフォーマンスのために、JDK 17とClojure CLIを依存関係のキャッシュとともにセットアップ
- NVD APIキーを使用して`clj-watson`脆弱性スキャンを実行し、JSON/HTMLレポートを成果物としてアップロード
- 脆弱性が検出された場合、ラベル付きのGitHub issueを自動的に作成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a GitHub Actions Security Scan workflow to perform monthly vulnerability scans on Clojure dependencies and automatically report findings.

CI:
- Introduce Security Scan workflow triggered monthly and via manual dispatch
- Set up JDK 17 and Clojure CLI with dependency caching for scan performance
- Run clj-watson vulnerability scan using the NVD API key and upload JSON/HTML reports as artifacts
- Automatically create a labeled GitHub issue when vulnerabilities are detected

</details>