### PR TITLE
:recycle: fixed security scan ci

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:linters {:inline-def {:level :off}}}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   vulnerability-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - uses: actions/checkout@v4
@@ -34,12 +37,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clojure-
 
-      - name: Run vulnerability scan
+      - name: Install Leiningen
+        run: |
+          wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+          chmod +x lein
+          sudo mv lein /usr/local/bin/
+          lein version
+
+      - name: Run vulnerability scan with nvd-clojure
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
-          clojure -Sdeps '{:deps {io.github.clj-holmes/clj-watson {:git/tag "v6.0.1" :git/sha "b520351"}}}' \
-                  -M -m clj-watson.cli scan -p project.clj
+          lein update-in :plugins conj "[lein-nvd \"2.1.0\"]" -- nvd check
 
       - name: Upload scan results
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target/
 .lsp/
-.clj-kondo/
+.clj-kondo/.cache/
 .lein-failures
 .claude
 .lein/


### PR DESCRIPTION
## Sourceryによる要約

セキュリティスキャンCIワークフローを更新し、Leiningenのインストール、ジョブ権限の調整、カスタムスキャン呼び出しの置き換えによってlein-nvd脆弱性スキャナーを使用するようにします。また、プロジェクト設定にlein-nvdプラグインを追加します。

機能強化:
- 統合された脆弱性スキャンを実現するため、`project.clj`にlein-nvdプラグインを追加

CI:
- 脆弱性スキャンジョブで、`contents`への読み取りアクセスと`issues`への書き込みアクセスを付与
- CIランナーにLeiningenをインストールするステップを追加
- カスタムのClojureベースのスキャン呼び出しを`lein nvd check`に置き換え

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the security scan CI workflow to use the lein-nvd vulnerability scanner by installing Leiningen, adjusting job permissions, and replacing the custom scan invocation, and add the lein-nvd plugin to the project configuration.

Enhancements:
- Add the lein-nvd plugin to project.clj for integrated vulnerability scanning

CI:
- Grant read access to contents and write access to issues in the vulnerability scan job
- Add a step to install Leiningen in the CI runner
- Replace the custom clojure-based scan invocation with `lein nvd check`

</details>